### PR TITLE
Gracefully handle events that are not found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ function Cal (opts) {
         var pending = 1 + row.links.length
         row.links.forEach(function (link) {
           cal.get(link, function (err, ldoc) {
-            if (err) return next(err)
+            if (err && err.notFound) return next()
+            else if (err) return next(err)
             batch.push.apply(batch, cal.prepare(ldoc.time, {
               type: 'del',
               id: link,


### PR DESCRIPTION
Since `calendar-db` removes deleted keys from its levelup, `hyperlog-calendar-index` will do a `cal.get(...)` when following an entry's `row.links`, resulting in an `err.notFound`. I think(?) this is a reasonable fix -- tests do pass.

(This can be reproduced by deleted an event in `norcal` and then trying to view your calendar again.)